### PR TITLE
v0.0.3 - fix broken completion, add missing commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.0.3
+
+- fixes broken completion after `from <module> import`, to allow for completion of module members
+- implements missing commands: `nile.compile`, `nile.compile.all`, `nile.clean`, and `pytest`
+- adds `cairols.serverModule` config, to allow for user specification of the language server implementation
+
 ## 0.0.2
 
 - remove `cairo` configuration namespace (`cairo.enabled`) was the only option

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coc-cairo",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A coc.nvim wrapper for the Cairo language server",
   "author": "Kevin Halliday <halliday.kevin7@gmail.com>",
   "repository": "https://github.com/kevinhalliday/coc-cairo",
@@ -53,6 +53,11 @@
           ],
           "default": "autodetect",
           "description": "Specifies which compiler to use for diagnostic highlighting."
+        },
+        "cairols.serverModule": {
+          "scope": "resource",
+          "type": "string",
+          "description": "Absolute path to a language server Node module to use. Useful for testing new language server implementations with this extension."
         },
         "cairols.sourceDir": {
           "scope": "resource",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,124 @@
-import path from 'path'
 import {
-  services,
+  workspace,
+  commands,
+  window,
+  Uri,
   ServerOptions,
   LanguageClientOptions,
   ExtensionContext,
   LanguageClient,
+  TransportKind,
 } from 'coc.nvim'
 
-export async function activate(context: ExtensionContext): Promise<void> {
+let client: LanguageClient
+
+export async function activate(context: ExtensionContext) {
+  const serverModule =
+    workspace.getConfiguration('cairols').get<string>('serverModule') ??
+    context.asAbsolutePath('node_modules/cairo-ls/out/server.js')
+
   const serverOptions: ServerOptions = {
-    module: path.join(
-      path.dirname(__dirname),
-      'node_modules/cairo-ls/out/server.js',
-    ),
+    run: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+    },
+    debug: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+      options: {
+        execArgv: ['--nolazy', '--inspect=6009'],
+      },
+    },
   }
 
   const clientOptions: LanguageClientOptions = {
-    documentSelector: ['cairo'],
+    documentSelector: [
+      'cairo',
+      {
+        pattern: '**/*.cairo',
+        scheme: 'file',
+      },
+    ],
+    synchronize: {
+      // Notify the server about file changes to '.cairo files contained in the workspace
+      fileEvents: workspace.createFileSystemWatcher('**/*.cairo'),
+    },
   }
 
-  const client = new LanguageClient(
-    'coc-cairo', // the id
-    'coc-cairo', // the name of the language server
+  registerCommands(context)
+
+  client = new LanguageClient(
+    'coc-cairo',
+    'coc-cairo',
     serverOptions,
     clientOptions,
   )
 
-  context.subscriptions.push(services.registLanguageClient(client))
+  client.start()
+}
+
+function join(...args: (string | boolean | null | undefined)[]) {
+  return args.filter(s => !!s).join(' ')
+}
+
+function call(command: string) {
+  window.openTerminal(command, { autoclose: false })
+}
+
+async function getCurrentFilename() {
+  const doc = await workspace.document
+  return Uri.parse(doc.uri).fsPath
+}
+
+/**
+ * Registers the following commands:
+ *
+ *  nile.compile      - Compile the current file
+ *  nile.compile.all  - Compile all files
+ *  nile.clean        - Clean up compilation artifacts
+ *  pytest            - Run pytest
+ */
+function registerCommands(context: ExtensionContext) {
+  const config = workspace.getConfiguration('cairols')
+  const sourceDir = config.get<string>('sourceDir')
+  const nileUseVenv = config.get<boolean>('nileUseVenv')
+  const nileVenvCommand = config.get<string>('nileVenvCommand')
+
+  // prefix all calls with nile venv activation
+  const commandPrefix =
+    nileUseVenv && nileVenvCommand ? join(nileVenvCommand, '&&') : null
+
+  // nile compile takes an optional --directory argument
+  const sourceDirParam = sourceDir ? join('--directory', sourceDir) : null
+
+  // > nile compile <filename> - compile a single file
+  const compileCommand = (filename: string) =>
+    join(commandPrefix, 'nile', 'compile', sourceDirParam, filename)
+
+  // > nile compile - compile all files
+  const compileAllCommand = join(
+    commandPrefix,
+    'nile',
+    'compile',
+    sourceDirParam,
+  )
+
+  // > nile clean - clean compiled contracts
+  const cleanCommand = join(commandPrefix, 'nile', 'clean')
+
+  const compile = async () => call(compileCommand(await getCurrentFilename()))
+  const compileAll = () => call(compileAllCommand)
+  const clean = () => call(cleanCommand)
+  const test = () => call('pytest')
+
+  context.subscriptions.push(
+    commands.registerCommand('nile.compile', compile),
+    commands.registerCommand('nile.compile.all', compileAll),
+    commands.registerCommand('nile.clean', clean),
+    commands.registerCommand('pytest', test),
+  )
+}
+
+export async function deactivate() {
+  return client?.stop()
 }


### PR DESCRIPTION
- completion after the `import` keyword was broken, so users could not
  complete on module members. The fix required setting the `transport`
  to `TransportKind.ipc`
- implements the following (previosuly configurable but not implemented)
  commands: nile.compile, nile.compile.all, nile.clean, pytest
- adds a `serverModule` configuration to allow for user specification of
  language server implementation